### PR TITLE
Schema: Account for NPC's without an inventory

### DIFF
--- a/gamemodes/ix_cotz/plugins/inworldtasks/items/miscellaneous/sh_gpstracker.lua
+++ b/gamemodes/ix_cotz/plugins/inworldtasks/items/miscellaneous/sh_gpstracker.lua
@@ -16,7 +16,8 @@ ITEM.iconCam = {
 
 function ITEM:GetDescription()
 	if(self.entity) then return self.description end
-	if(!self:GetOwner()) then return self.description end
+	local success, owner = pcall(self.GetOwner, self)
+	if success and (not owner) then return self.description end
 
 	local desc = self.description.."\n\n"
 	local ppos = ix.util.GetLongLatFromVector(self:GetOwner():GetPos())


### PR DESCRIPTION
Account for NPC's who have a character but not an inventory, this causes an index nil error in places such as when purchasing the GPS Tracker from the Mute.

Uses pcall instead of writing a new function, as it makes more sense and is much cleaner.